### PR TITLE
feat(agent): add run() method to all agent classes

### DIFF
--- a/mcp_arena/agent/interfaces.py
+++ b/mcp_arena/agent/interfaces.py
@@ -98,6 +98,22 @@ class IAgent(ABC):
         pass
     
     @abstractmethod
+    def run(self, input_data: Any) -> Any:
+        """Run the agent with given input and return response.
+        
+        This is the primary method for executing an agent. It serves as
+        a convenience wrapper that provides a consistent interface across
+        all agent implementations.
+        
+        Args:
+            input_data: The input to process (typically a string query)
+            
+        Returns:
+            The agent's response after processing the input
+        """
+        pass
+    
+    @abstractmethod
     def process(self, input_data: Any) -> Any:
         """Process input and return response"""
         pass

--- a/mcp_arena/agent/planning_agent.py
+++ b/mcp_arena/agent/planning_agent.py
@@ -35,6 +35,20 @@ class PlanningAgent(BaseAgent, IAgent):
         if "llm" in config:
             self.llm = config["llm"]
     
+    def run(self, input_data: Any) -> Any:
+        """Run the agent with given input and return response.
+        
+        This is the primary method for executing the Planning agent.
+        It delegates to process() for the actual execution.
+        
+        Args:
+            input_data: The input to process (typically a string query)
+            
+        Returns:
+            The agent's response after planning and execution
+        """
+        return self.process(input_data)
+    
     def process(self, input_data: Any) -> Any:
         """Process input and return response"""
         if isinstance(input_data, str):

--- a/mcp_arena/agent/react_agent.py
+++ b/mcp_arena/agent/react_agent.py
@@ -42,6 +42,20 @@ class ReactAgent(BaseAgent, IAgent):
             self.add_node("configure_max_steps", 
                          lambda state: self._configure_max_steps(state, config["max_steps"]))
     
+    def run(self, input_data: Any) -> Any:
+        """Run the agent with given input and return response.
+        
+        This is the primary method for executing the ReAct agent.
+        It delegates to process() for the actual execution.
+        
+        Args:
+            input_data: The input to process (typically a string query)
+            
+        Returns:
+            The agent's response after reasoning and acting
+        """
+        return self.process(input_data)
+    
     def process(self, input_data: Any) -> Any:
         """Process input and return response"""
         if isinstance(input_data, str):

--- a/mcp_arena/agent/reflection_agent.py
+++ b/mcp_arena/agent/reflection_agent.py
@@ -40,6 +40,20 @@ class ReflectionAgent(BaseAgent, IAgent):
             self.add_node("configure_max_reflections", 
                          lambda state: self._configure_max_reflections(state, config["max_reflections"]))
     
+    def run(self, input_data: Any) -> Any:
+        """Run the agent with given input and return response.
+        
+        This is the primary method for executing the Reflection agent.
+        It delegates to process() for the actual execution.
+        
+        Args:
+            input_data: The input to process (typically a string query)
+            
+        Returns:
+            The agent's refined response after reflection
+        """
+        return self.process(input_data)
+    
     def process(self, input_data: Any) -> Any:
         """Process input and return response"""
         if isinstance(input_data, str):


### PR DESCRIPTION
- Add run() abstract method to IAgent interface
- Implement run() in ReactAgent, ReflectionAgent, and PlanningAgent
- run() provides a consistent API and delegates to process()
- Fixes failing test_agent_base_classes test

This change improves the agent API by adding a run() method that is consistent with common agent framework patterns (e.g., LangChain). The run() method serves as a convenience wrapper around process(), making the API more intuitive for users.

-  All 27 tests in `test_imports.py` pass
-  Previously failing `test_agent_base_classes` now passes
-  flake8 linting passes with 0 errors
