### PR TITLE
refactor(router): add BaseRouter class and IRouter interface for cons…

### DIFF
--- a/mcp_arena/agent/__init__.py
+++ b/mcp_arena/agent/__init__.py
@@ -30,8 +30,8 @@ Usage:
 """
 
 from .interfaces import (
-    IAgent, IAgentState, IAgentBehavior, IAgentMemory, 
-    IAgentTool, IAgentFactory, IAgentPolicy
+    IAgent, IAgentState, IAgentBehavior, IAgentMemory,
+    IAgentTool, IAgentFactory, IAgentPolicy, IRouter
 )
 
 from .base import BaseAgent
@@ -66,7 +66,7 @@ from .factory import (
 )
 
 from .router import (
-    AgentRouter, SmartRouter, MultiAgentOrchestrator,
+    BaseRouter, AgentRouter, SmartRouter, MultiAgentOrchestrator,
     ConditionalRouter, create_default_router, create_research_router
 )
 
@@ -77,7 +77,7 @@ __author__ = "MCP Arena Team"
 __all__ = [
     # Interfaces
     "IAgent", "IAgentState", "IAgentBehavior", "IAgentMemory",
-    "IAgentTool", "IAgentFactory", "IAgentPolicy",
+    "IAgentTool", "IAgentFactory", "IAgentPolicy", "IRouter",
     
     # Core Agents
     "BaseAgent", "ReflectionAgent", "ReactAgent", "PlanningAgent",
@@ -102,7 +102,7 @@ __all__ = [
     "create_agent", "create_reflection_agent", "create_react_agent", "create_planning_agent",
     
     # Routing
-    "AgentRouter", "SmartRouter", "MultiAgentOrchestrator",
+    "BaseRouter", "AgentRouter", "SmartRouter", "MultiAgentOrchestrator",
     "ConditionalRouter", "create_default_router", "create_research_router",
 ]
 

--- a/mcp_arena/agent/interfaces.py
+++ b/mcp_arena/agent/interfaces.py
@@ -120,13 +120,63 @@ class IAgent(ABC):
 
 class IAgentPolicy(ABC):
     """Interface for agent policies"""
-    
+
     @abstractmethod
     def validate_action(self, action: Dict[str, Any]) -> bool:
         """Validate an action before execution"""
         pass
-    
+
     @abstractmethod
     def filter_response(self, response: Any) -> Any:
         """Filter/rate-limit responses"""
+        pass
+
+
+class IRouter(ABC):
+    """Base interface for all routers.
+
+    This provides a consistent API across all router types. The run() method
+    serves as the primary execution entry point, while route() determines
+    which agent handles the request.
+
+    All router implementations should inherit from this interface.
+    """
+
+    @abstractmethod
+    def route(self, input_text: str) -> 'IAgent':
+        """Route input to the appropriate agent.
+
+        Args:
+            input_text: The input text to route.
+
+        Returns:
+            The agent that should handle this input.
+        """
+        pass
+
+    @abstractmethod
+    def run(self, input_text: str) -> Any:
+        """Run the router with input text.
+
+        This is the primary execution method that provides a consistent API.
+        It routes the input and processes it through the selected agent.
+
+        Args:
+            input_text: The input text to process.
+
+        Returns:
+            The response from the routed agent.
+        """
+        pass
+
+    @abstractmethod
+    def process(self, input_text: str) -> Any:
+        """Process input using the routed agent.
+
+        Args:
+            input_text: The input text to process.
+
+        Returns:
+            The response from the agent.
+        """
         pass

--- a/mcp_arena/agent/planning_agent.py
+++ b/mcp_arena/agent/planning_agent.py
@@ -30,38 +30,52 @@ class PlanningAgent(BaseAgent, IAgent):
     def initialize(self, config: Dict[str, Any]) -> None:
         """Initialize the agent with configuration"""
         self.config = config
-        
+
         # Set up LLM if provided in config
         if "llm" in config:
             self.llm = config["llm"]
-    
+
+    def run(self, input_data: Any) -> Any:
+        """Run the agent with input data.
+
+        This is the primary execution method that provides a consistent API.
+        It delegates to process() for the actual execution logic.
+
+        Args:
+            input_data: The input to process (typically a string).
+
+        Returns:
+            The agent's formatted response with plan execution results.
+        """
+        return self.process(input_data)
+
     def process(self, input_data: Any) -> Any:
-        """Process input and return response"""
+        """Process input and return response."""
         if isinstance(input_data, str):
             # Create initial state
             initial_state = PlanningAgentState()
             initial_state.add_message({"type": "user", "content": input_data})
-            
+
             # Run the graph
             result = self.get_compiled_graph().invoke(initial_state)
-            
+
             # Return the final result
             return self._format_final_response(result)
-        
+
         return None
-    
+
     def get_compiled_graph(self) -> CompiledStateGraph:
-        """Get the compiled LangGraph"""
+        """Get the compiled LangGraph."""
         return self.compile()
-    
+
     def add_tool(self, tool: IAgentTool) -> None:
-        """Add a tool to the agent"""
+        """Add a tool to the agent."""
         self.tools.append(tool)
-    
+
     def set_memory(self, memory: IAgentMemory) -> None:
-        """Set the memory system"""
+        """Set the memory system."""
         self.memory = memory
-    
+
     def add_policy(self, policy: IAgentPolicy) -> None:
         """Add a policy to the agent"""
         self.policies.append(policy)

--- a/mcp_arena/agent/react_agent.py
+++ b/mcp_arena/agent/react_agent.py
@@ -36,33 +36,47 @@ class ReactAgent(BaseAgent, IAgent):
         # Set up LLM if provided in config
         if "llm" in config:
             self.llm = config["llm"]
-        
+
         # Configure max steps
         if "max_steps" in config:
-            self.add_node("configure_max_steps", 
+            self.add_node("configure_max_steps",
                          lambda state: self._configure_max_steps(state, config["max_steps"]))
-    
+
+    def run(self, input_data: Any) -> Any:
+        """Run the agent with input data.
+
+        This is the primary execution method that provides a consistent API.
+        It delegates to process() for the actual execution logic.
+
+        Args:
+            input_data: The input to process (typically a string).
+
+        Returns:
+            The agent's response (observation or thought).
+        """
+        return self.process(input_data)
+
     def process(self, input_data: Any) -> Any:
-        """Process input and return response"""
+        """Process input and return response."""
         if isinstance(input_data, str):
             # Create initial state
             initial_state = ReactAgentState()
             initial_state.add_message({"type": "user", "content": input_data})
-            
+
             # Run the graph
             result = self.get_compiled_graph().invoke(initial_state)
-            
+
             # Return the final observation or thought
             return result.observation or result.thought
-        
+
         return None
-    
+
     def get_compiled_graph(self) -> CompiledStateGraph:
-        """Get the compiled LangGraph"""
+        """Get the compiled LangGraph."""
         return self.compile()
-    
+
     def add_tool(self, tool: IAgentTool) -> None:
-        """Add a tool to the agent"""
+        """Add a tool to the agent."""
         self.tools.append(tool)
         self._update_tool_node()
     

--- a/mcp_arena/agent/reflection_agent.py
+++ b/mcp_arena/agent/reflection_agent.py
@@ -34,39 +34,53 @@ class ReflectionAgent(BaseAgent, IAgent):
         # Set up LLM if provided in config
         if "llm" in config:
             self.llm = config["llm"]
-        
+
         # Configure reflection parameters
         if "max_reflections" in config:
-            self.add_node("configure_max_reflections", 
+            self.add_node("configure_max_reflections",
                          lambda state: self._configure_max_reflections(state, config["max_reflections"]))
-    
+
+    def run(self, input_data: Any) -> Any:
+        """Run the agent with input data.
+
+        This is the primary execution method that provides a consistent API.
+        It delegates to process() for the actual execution logic.
+
+        Args:
+            input_data: The input to process (typically a string).
+
+        Returns:
+            The agent's response (refined or initial response).
+        """
+        return self.process(input_data)
+
     def process(self, input_data: Any) -> Any:
-        """Process input and return response"""
+        """Process input and return response."""
         if isinstance(input_data, str):
             # Create initial state
             initial_state = ReflectionAgentState()
             initial_state.add_message({"type": "user", "content": input_data})
-            
+
             # Run the graph
             result = self.get_compiled_graph().invoke(initial_state)
-            
+
             # Return the final response
             return result.refined_response or result.initial_response
-        
+
         return None
-    
+
     def get_compiled_graph(self) -> CompiledStateGraph:
-        """Get the compiled LangGraph"""
+        """Get the compiled LangGraph."""
         return self.compile()
-    
+
     def add_tool(self, tool: IAgentTool) -> None:
-        """Add a tool to the agent"""
+        """Add a tool to the agent."""
         self.tools.append(tool)
-    
+
     def set_memory(self, memory: IAgentMemory) -> None:
-        """Set the memory system"""
+        """Set the memory system."""
         self.memory = memory
-    
+
     def add_policy(self, policy: IAgentPolicy) -> None:
         """Add a policy to the agent"""
         self.policies.append(policy)

--- a/mcp_arena/agent/router.py
+++ b/mcp_arena/agent/router.py
@@ -1,51 +1,107 @@
 from typing import Any, Dict, List, Optional, Callable
-from .interfaces import IAgent, IAgentBehavior, IAgentState
+from .interfaces import IAgent, IRouter
 from .factory import AgentFactory
 
 
-class AgentRouter:
-    """Router for directing requests to appropriate agents"""
-    
+class BaseRouter(IRouter):
+    """Base class for all routers.
+
+    Provides a consistent API with run() as the primary execution method.
+    Subclasses should implement the route() method and optionally override
+    run() or process() for custom behavior.
+
+    This follows the Template Method pattern where:
+    - run() is the public API (template method)
+    - process() contains the algorithm skeleton
+    - route() is the hook method subclasses must implement
+    """
+
     def __init__(self, factory: AgentFactory = None):
+        """Initialize the router with an optional agent factory.
+
+        Args:
+            factory: The agent factory to use for creating agents.
+                    If None, a default AgentFactory is created.
+        """
         self.factory = factory or AgentFactory()
+
+    def run(self, input_text: str) -> Any:
+        """Run the router with input text.
+
+        This is the primary execution method that provides a consistent API.
+        It delegates to process() by default.
+
+        Args:
+            input_text: The input text to process.
+
+        Returns:
+            The response from the routed agent.
+        """
+        return self.process(input_text)
+
+    def process(self, input_text: str) -> Any:
+        """Process input using the routed agent.
+
+        Routes the input and processes it through the selected agent.
+        Can be overridden by subclasses for custom behavior.
+
+        Args:
+            input_text: The input text to process.
+
+        Returns:
+            The response from the agent.
+        """
+        agent = self.route(input_text)
+        return agent.process(input_text)
+
+
+class AgentRouter(BaseRouter):
+    """Router for directing requests to appropriate agents.
+
+    Supports rule-based routing with conditions and a default fallback agent.
+    """
+
+    def __init__(self, factory: AgentFactory = None):
+        super().__init__(factory)
         self.routes: List[Dict[str, Any]] = []
         self.default_agent: Optional[IAgent] = None
-    
+
     def add_route(self, condition: Callable[[str], bool], agent_type: str, config: Dict[str, Any] = None) -> None:
-        """Add a routing rule"""
+        """Add a routing rule.
+
+        Args:
+            condition: A function that returns True if this route should handle the input.
+            agent_type: The type of agent to create for this route.
+            config: Optional configuration for the agent.
+        """
         self.routes.append({
             "condition": condition,
             "agent_type": agent_type,
             "config": config or {}
         })
-    
+
     def set_default_agent(self, agent_type: str, config: Dict[str, Any] = None) -> None:
-        """Set the default agent for unmatched requests"""
+        """Set the default agent for unmatched requests."""
         self.default_agent = self.factory.create_agent(agent_type, config or {})
-    
+
     def route(self, input_text: str) -> IAgent:
-        """Route input to the appropriate agent"""
+        """Route input to the appropriate agent."""
         # Check routes in order
         for route in self.routes:
             if route["condition"](input_text):
                 return self.factory.create_agent(route["agent_type"], route["config"])
-        
+
         # Return default agent if no routes match
         if self.default_agent:
             return self.default_agent
-        
+
         # Create a basic reflection agent as fallback
         return self.factory.create_agent("reflection")
-    
-    def process(self, input_text: str) -> Any:
-        """Process input using the routed agent"""
-        agent = self.route(input_text)
-        return agent.process(input_text)
 
 
 class SmartRouter(AgentRouter):
-    """Smart router that uses LLM-based routing decisions"""
-    
+    """Smart router that uses LLM-based routing decisions."""
+
     def __init__(self, factory: AgentFactory = None, llm=None):
         super().__init__(factory)
         self.llm = llm
@@ -91,25 +147,71 @@ Respond with just the agent type name (reflection, react, or planning):"""
         return self.factory.create_agent(agent_type)
 
 
-class MultiAgentOrchestrator:
-    """Orchestrator that can coordinate multiple agents for complex tasks"""
-    
+class MultiAgentOrchestrator(BaseRouter):
+    """Orchestrator that can coordinate multiple agents for complex tasks.
+
+    This router coordinates workflows across multiple registered agents,
+    supporting both sequential and parallel execution patterns.
+    """
+
     def __init__(self, factory: AgentFactory = None):
-        self.factory = factory or AgentFactory()
+        super().__init__(factory)
         self.agents: Dict[str, IAgent] = {}
         self.workflows: List[Dict[str, Any]] = []
-    
+        self._default_workflow: Optional[str] = None
+
     def register_agent(self, name: str, agent_type: str, config: Dict[str, Any] = None) -> None:
-        """Register an agent with a name"""
+        """Register an agent with a name."""
         agent = self.factory.create_agent(agent_type, config or {})
         self.agents[name] = agent
-    
-    def add_workflow(self, name: str, steps: List[Dict[str, Any]]) -> None:
-        """Add a workflow that coordinates multiple agents"""
+
+    def add_workflow(self, name: str, steps: List[Dict[str, Any]], is_default: bool = False) -> None:
+        """Add a workflow that coordinates multiple agents.
+
+        Args:
+            name: The workflow name.
+            steps: List of workflow steps, each containing 'agent' key.
+            is_default: If True, this workflow is used by run().
+        """
         self.workflows.append({
             "name": name,
             "steps": steps
         })
+        if is_default:
+            self._default_workflow = name
+
+    def route(self, input_text: str) -> IAgent:
+        """Route to the first agent in the default workflow.
+
+        For orchestrator, routing is less meaningful - use run() or
+        execute_workflow() instead for proper workflow execution.
+        """
+        if self._default_workflow:
+            for wf in self.workflows:
+                if wf["name"] == self._default_workflow and wf["steps"]:
+                    first_agent_name = wf["steps"][0]["agent"]
+                    if first_agent_name in self.agents:
+                        return self.agents[first_agent_name]
+
+        # Return first registered agent or create a fallback
+        if self.agents:
+            return next(iter(self.agents.values()))
+        return self.factory.create_agent("reflection")
+
+    def run(self, input_text: str, workflow_name: str = None) -> Any:
+        """Run the orchestrator with input text.
+
+        Args:
+            input_text: The input to process.
+            workflow_name: Optional workflow to execute. If None, uses default.
+
+        Returns:
+            Workflow results if a workflow is executed, otherwise process() result.
+        """
+        target_workflow = workflow_name or self._default_workflow
+        if target_workflow:
+            return self.execute_workflow(target_workflow, input_text)
+        return self.process(input_text)
     
     def execute_workflow(self, workflow_name: str, initial_input: Any) -> Dict[str, Any]:
         """Execute a workflow across multiple agents"""
@@ -164,43 +266,43 @@ class MultiAgentOrchestrator:
         return results
 
 
-class ConditionalRouter:
-    """Router that uses conditional logic for routing decisions"""
-    
+class ConditionalRouter(BaseRouter):
+    """Router that uses conditional logic with priority-based routing decisions."""
+
     def __init__(self, factory: AgentFactory = None):
-        self.factory = factory or AgentFactory()
+        super().__init__(factory)
         self.conditions: List[Dict[str, Any]] = []
         self.default_route: Optional[Dict[str, Any]] = None
-    
-    def add_condition(self, 
-                     condition: Callable[[str], bool], 
-                     agent_type: str, 
+
+    def add_condition(self,
+                     condition: Callable[[str], bool],
+                     agent_type: str,
                      config: Dict[str, Any] = None,
                      priority: int = 0) -> None:
-        """Add a conditional routing rule"""
+        """Add a conditional routing rule with priority."""
         self.conditions.append({
             "condition": condition,
             "agent_type": agent_type,
             "config": config or {},
             "priority": priority
         })
-        
+
         # Sort by priority (higher priority first)
         self.conditions.sort(key=lambda x: x["priority"], reverse=True)
-    
+
     def set_default(self, agent_type: str, config: Dict[str, Any] = None) -> None:
-        """Set the default route"""
+        """Set the default route."""
         self.default_route = {
             "agent_type": agent_type,
             "config": config or {}
         }
-    
+
     def route(self, input_text: str) -> IAgent:
-        """Route based on conditions"""
+        """Route based on conditions."""
         for condition in self.conditions:
             if condition["condition"](input_text):
                 return self.factory.create_agent(
-                    condition["agent_type"], 
+                    condition["agent_type"],
                     condition["config"]
                 )
         


### PR DESCRIPTION
Summary
Add `IRouter` interface and `BaseRouter` base class following the owner's feedback to use a base class approach for all routers.

Changes
- Add `IRouter` abstract interface with `route()`, `run()`, `process()` methods
- Add `BaseRouter` class implementing `IRouter` with default `run()` and `process()`
- Update `AgentRouter` to extend `BaseRouter`
- Update `SmartRouter` to inherit from `AgentRouter` (inherits `BaseRouter`)
- Update `MultiAgentOrchestrator` to extend `BaseRouter`
- Update `ConditionalRouter` to extend `BaseRouter`
- Export `IRouter` and `BaseRouter` from `__init__.py`

Benefits:
- **DRY**: `run()` and `process()` defined once in `BaseRouter`
- **Polymorphism**: Treat all routers uniformly via `IRouter`
- **Maintainability**: Future changes happen in ONE place
- **Template Method Pattern**: Clear separation of extension points
Testing
- ✅ All 47 agent and import tests pass
- ✅ flake8 linting passes

Closes #16