### PR TITLE
Add filtering and sorting support to agent type listings

### DIFF
--- a/mcp_arena/agent/factory.py
+++ b/mcp_arena/agent/factory.py
@@ -1,4 +1,6 @@
 from typing import Any, Dict, List, Type, Optional
+
+from cv2 import sort
 from .interfaces import IAgent, IAgentFactory, IAgentTool, IAgentMemory, IAgentPolicy
 from .reflection_agent import ReflectionAgent
 from .react_agent import ReactAgent
@@ -45,9 +47,32 @@ class AgentFactory(IAgentFactory):
         """Set default configuration for an agent type"""
         self._default_config[agent_type] = config
     
-    def list_agent_types(self) -> List[str]:
-        """List all registered agent types"""
-        return list(self._agent_types.keys())
+
+        def list_agent_types(
+        self,
+        filter_prefix: Optional[str] = None,
+        sort: bool = False
+    ) -> List[str]:
+         """
+        List all registered agent types with optional filtering and sorting.
+
+        :param filter_prefix: Only include agent types starting with this prefix
+        :param sort: Whether to sort agent types alphabetically
+        """
+        agent_types = list(self._agent_types.keys())
+
+        if filter_prefix:
+            agent_types = [
+                a for a in agent_types
+                if a.startswith(filter_prefix)
+            ]
+
+        if sort:
+            agent_types.sort()
+
+        return agent_types
+
+
     
     def _register_builtin_agents(self) -> None:
         """Register built-in agent types"""


### PR DESCRIPTION
## Description

This PR adds optional filtering and sorting support to agent type listings.

The `list_agent_types` method in `AgentFactory` has been extended to:
- Filter agent types by a given prefix
- Sort agent types alphabetically when requested

These changes are backward-compatible and do not affect existing functionality unless the new parameters are explicitly used.

## Changes Made
- Updated `list_agent_types` to accept optional `filter_prefix` and `sort` parameters
- Added clear docstrings explaining the new behavior


## Related Issue
Closes #22
