### PR TITLE
Fix CLI argument parsing: prevent automatic int conversion of numeric…

### DIFF
--- a/mcp_arena/cli.py
+++ b/mcp_arena/cli.py
@@ -462,11 +462,14 @@ def _parse_cli_args(args: List[str]) -> Dict[str, Any]:
             key = arg.lstrip("-").replace("-", "_")
             if i + 1 < len(args) and not args[i + 1].startswith("--"):
                 value = args[i + 1]
-                # Try to convert to appropriate type
+
+                # Convert only boolean values
                 if value.lower() in ("true", "false"):
                     value = value.lower() == "true"
-                elif value.isdigit():
-                    value = int(value)
+
+                # IMPORTANT: Do NOT auto-convert digits to int
+                # Tokens, API keys, etc. must remain strings
+
                 kwargs[key] = value
                 i += 2
             else:
@@ -475,7 +478,6 @@ def _parse_cli_args(args: List[str]) -> Dict[str, Any]:
         else:
             i += 1
     return kwargs
-
 
 @app.command(
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True}


### PR DESCRIPTION
### Summary
Fix CLI argument parsing so numeric strings (e.g., tokens, API keys) are not automatically converted to integers.

### Problem
The `_parse_cli_args` function converted digit-only values to int.
This caused tokens like "123" to be passed as integers, breaking CLI tests.

### Fix
Removed automatic integer conversion.
Boolean values are still converted properly.

### Result
Fixes failing CLI test and ensures correct token handling.