### PR TITLE
Fix SlackMCPServer recursion and attribute delegation issue

### DIFF
--- a/mcp_arena/presents/slack.py
+++ b/mcp_arena/presents/slack.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, asdict, field
 from enum import Enum
 import os
 import json
-from slack_sdk import WebClient
+import slack_sdk
 from slack_sdk.errors import SlackApiError
 from mcp_arena.mcp.server import BaseMCPServer
 
@@ -79,15 +79,26 @@ class SlackMCPServer(BaseMCPServer):
             auto_register_tools: Automatically register tools on initialization
             **base_kwargs: Additional arguments for BaseMCPServer
         """
-        self.__token = token or os.getenv("SLACK_TOKEN")
-        if not self.__token:
-            raise ValueError(
-                "Slack token is required. "
-                "Provide it as argument or set SLACK_TOKEN environment variable."
+        bot_token = base_kwargs.pop("bot_token", None)
+
+        resolved_token = (
+                      token
+                      or bot_token
+                      or os.getenv("SLACK_TOKEN")
+        )
+
+        if not resolved_token:
+           raise ValueError(
+            "Slack token is required. "
+               "Provide it as argument or set SLACK_TOKEN environment variable."
             )
+
+        # Bypass BaseMCPServer attribute delegation
+        object.__setattr__(self, "bot_token", resolved_token)
+        object.__setattr__(self, "auto_register_tools", auto_register_tools)
         
         # Initialize Slack client
-        self.client = WebClient(token=self.__token)
+        self.client = slack_sdk.WebClient(token=self.bot_token)
         
         # Initialize base class
         super().__init__(

--- a/tests/test_communication_services.py
+++ b/tests/test_communication_services.py
@@ -1,5 +1,5 @@
 """Test communication services specifically."""
-
+import warnings
 import pytest
 from unittest.mock import Mock, patch, MagicMock
 
@@ -52,7 +52,7 @@ class TestGmailService:
             from googleapiclient.discovery import build
             assert google.auth is not None
         except ImportError as e:
-            pytest.warn(f"Gmail dependencies not available: {e}")
+            warnings.warn(f"Gmail dependencies not available: {e}")
 
 
 class TestOutlookService:
@@ -106,7 +106,7 @@ class TestOutlookService:
             import msal
             assert msal is not None
         except ImportError as e:
-            pytest.warn(f"Outlook dependencies not available: {e}")
+            warnings.warn(f"Outlook dependencies not available: {e}")
 
 
 class TestWhatsAppService:
@@ -160,7 +160,7 @@ class TestWhatsAppService:
             import twilio
             assert twilio is not None
         except ImportError as e:
-            pytest.warn(f"WhatsApp dependencies not available: {e}")
+            warnings.warn(f"WhatsApp dependencies not available: {e}")
 
 
 class TestSlackService:
@@ -205,7 +205,7 @@ class TestSlackService:
             import slack_sdk
             assert slack_sdk is not None
         except ImportError as e:
-            pytest.warn(f"Slack dependencies not available: {e}")
+            warnings.warn(f"Slack dependencies not available: {e}")
 
 
 class TestCommunicationServicesIntegration:
@@ -328,7 +328,7 @@ class TestCommunicationServicesDependencies:
             try:
                 __import__(module)
             except ImportError:
-                pytest.warn(f"Email dependency '{module}' for {service} not available")
+                warnings.warn(f"Email dependency '{module}' for {service} not available")
 
     def test_messaging_dependencies(self):
         """Test messaging service dependencies."""
@@ -341,7 +341,7 @@ class TestCommunicationServicesDependencies:
             try:
                 __import__(module)
             except ImportError:
-                pytest.warn(f"Messaging dependency '{module}' for {service} not available")
+                warnings.warn(f"Messaging dependency '{module}' for {service} not available")
 
     def test_communication_package_versions(self):
         """Test communication package versions are compatible."""
@@ -360,9 +360,9 @@ class TestCommunicationServicesDependencies:
                     # Basic version check - just ensure it exists
                     assert version is not None
                 else:
-                    pytest.warn(f"Could not determine version for {package}")
+                    warnings.warn(f"Could not determine version for {package}")
             except ImportError:
-                pytest.warn(f"Package {package} not available")
+                warnings.warn(f"Package {package} not available")
 
 
 class TestCommunicationServicesPerformance:


### PR DESCRIPTION
## Summary
Fix recursion error in SlackMCPServer caused by BaseMCPServer attribute delegation.

## Problem
Custom attributes like `bot_token` and `auto_register_tools` were triggering infinite recursion due to overridden `__getattr__` in BaseMCPServer.

## Fix
- Used `object.__setattr__` to safely assign custom attributes
- Ensured Slack WebClient initialization works correctly
- Updated tests to replace deprecated pytest.warn usage

## Result
- Slack service tests now pass successfully
- No breaking changes to existing behavior
- Improved attribute safety in server wrapper