### PR TITLE
Add Minimal End-to-End MCP Server Examples

### DIFF
--- a/examples/01_hello_server.py
+++ b/examples/01_hello_server.py
@@ -1,0 +1,56 @@
+"""
+01_hello_server.py — Minimal MCP Server with One Tool
+
+This is the simplest possible MCP server using mcp_arena.
+It registers a single "greet" tool that returns a greeting message.
+
+Usage:
+    python 01_hello_server.py
+
+What it demonstrates:
+    - Subclassing BaseMCPServer
+    - Registering a tool with @self.mcp_server.tool()
+    - Running the server with stdio transport
+"""
+
+from mcp_arena import BaseMCPServer
+
+
+class HelloServer(BaseMCPServer):
+    """A minimal MCP server with one tool."""
+
+    def __init__(self):
+        super().__init__(
+            name="hello-server",
+            description="A minimal MCP server that greets users",
+            transport="stdio",  # Use stdio for local development
+        )
+
+    def _register_tools(self) -> None:
+        """Register all tools with the MCP server."""
+
+        @self.mcp_server.tool()
+        def greet(name: str) -> str:
+            """Greet a user by name.
+
+            Args:
+                name: The name of the person to greet.
+
+            Returns:
+                A friendly greeting message.
+            """
+            return f"Hello, {name}! Welcome to mcp_arena."
+
+        # Track registered tools
+        self._registered_tools.append("greet")
+
+
+# --- Entry Point ---
+if __name__ == "__main__":
+    server = HelloServer()
+
+    print(f"Server: {server.name}")
+    print(f"Tools:  {server.get_registered_tools()}")
+    print("Starting server on stdio transport...")
+
+    server.run()

--- a/examples/02_prompt_and_tool.py
+++ b/examples/02_prompt_and_tool.py
@@ -1,0 +1,77 @@
+"""
+02_prompt_and_tool.py — MCP Server with a Tool and a Prompt
+
+Builds on the hello server by adding a reusable prompt template.
+Prompts let you define structured instruction templates that clients
+can retrieve and fill in with arguments.
+
+Usage:
+    python 02_prompt_and_tool.py
+
+What it demonstrates:
+    - Registering a tool with @self.mcp_server.tool()
+    - Registering a prompt with @self.mcp_server.prompt()
+    - Combining tools and prompts in one server
+"""
+
+from mcp_arena import BaseMCPServer
+
+
+class PromptToolServer(BaseMCPServer):
+    """MCP server with a tool and a prompt template."""
+
+    def __init__(self):
+        super().__init__(
+            name="prompt-tool-server",
+            description="MCP server demonstrating tools and prompts together",
+            transport="stdio",
+        )
+
+    def _register_tools(self) -> None:
+        """Register tools and prompts."""
+
+        # --- Tool: Summarize text ---
+        @self.mcp_server.tool()
+        def summarize(text: str, max_words: int = 50) -> str:
+            """Summarize a piece of text.
+
+            Args:
+                text: The text to summarize.
+                max_words: Maximum number of words in the summary.
+
+            Returns:
+                A shortened version of the text.
+            """
+            words = text.split()
+            if len(words) <= max_words:
+                return text
+            return " ".join(words[:max_words]) + "..."
+
+        self._registered_tools.append("summarize")
+
+        # --- Prompt: Summary request template ---
+        @self.mcp_server.prompt()
+        def summary_prompt(topic: str) -> str:
+            """Generate a prompt asking for a summary of a topic.
+
+            Args:
+                topic: The topic to summarize.
+
+            Returns:
+                A formatted prompt string.
+            """
+            return (
+                f"Please provide a concise summary of the following topic: {topic}. "
+                f"Focus on the key points and keep it brief."
+            )
+
+
+# --- Entry Point ---
+if __name__ == "__main__":
+    server = PromptToolServer()
+
+    print(f"Server: {server.name}")
+    print(f"Tools:  {server.get_registered_tools()}")
+    print("Starting server on stdio transport...")
+
+    server.run()

--- a/examples/03_agent_flow.py
+++ b/examples/03_agent_flow.py
@@ -1,0 +1,157 @@
+"""
+03_agent_flow.py — Full End-to-End: Server → Agent → Tool Execution
+
+This example shows the complete mcp_arena pipeline:
+  1. Create an MCP server with custom tools
+  2. Wrap the server tools for agent use
+  3. Create an agent (ReAct or Reflection)
+  4. Process a user query through the agent
+
+Usage:
+    python 03_agent_flow.py
+
+What it demonstrates:
+    - Building a custom MCP server with tools
+    - Using MCPAgentWrapper to bridge server tools to agents
+    - Creating agents with AgentFactory / AgentBuilder
+    - Processing queries through the agent pipeline
+"""
+
+from mcp_arena import BaseMCPServer
+from mcp_arena.agent.factory import AgentFactory, AgentBuilder
+from mcp_arena.agent.tools import CalculatorTool
+from mcp_arena.wrapper.agent_wrapper import MCPAgentWrapper
+
+
+# ─── Step 1: Define a Custom MCP Server ──────────────────────────────────────
+
+class MathServer(BaseMCPServer):
+    """MCP server with a simple math tool."""
+
+    def __init__(self):
+        super().__init__(
+            name="math-server",
+            description="A minimal math server for the agent flow example",
+            transport="stdio",
+        )
+
+    def _register_tools(self) -> None:
+        """Register math tools."""
+
+        @self.mcp_server.tool()
+        def add(a: int, b: int) -> int:
+            """Add two numbers together.
+
+            Args:
+                a: First number.
+                b: Second number.
+
+            Returns:
+                The sum of a and b.
+            """
+            return a + b
+
+        @self.mcp_server.tool()
+        def multiply(a: int, b: int) -> int:
+            """Multiply two numbers.
+
+            Args:
+                a: First number.
+                b: Second number.
+
+            Returns:
+                The product of a and b.
+            """
+            return a * b
+
+        self._registered_tools.extend(["add", "multiply"])
+
+
+# ─── Step 2: Wrap Server Tools for Agent Use ─────────────────────────────────
+
+def wrap_server_tools():
+    """Create an MCP server and wrap its tools for agent consumption."""
+    server = MathServer()
+
+    # MCPAgentWrapper bridges MCP tools → agent-compatible tools
+    wrapper = MCPAgentWrapper(server)
+
+    print(f"Server '{server.name}' has {len(wrapper.tools)} wrapped tools:")
+    for tool in wrapper.tools:
+        print(f"  - {tool.name}: {tool.description}")
+
+    return wrapper
+
+
+# ─── Step 3: Create an Agent ─────────────────────────────────────────────────
+
+def create_agent_with_factory():
+    """Create a ReAct agent using the AgentFactory."""
+    factory = AgentFactory()
+
+    # List available agent types
+    print(f"Available agent types: {factory.list_agent_types()}")
+
+    # Create a ReAct agent (Reasoning + Acting)
+    agent = factory.create_agent("react", config={
+        "memory_type": "conversation",
+        "max_steps": 5,
+    })
+
+    return agent
+
+
+def create_agent_with_builder():
+    """Create a ReAct agent using the Builder pattern."""
+    agent = (
+        AgentBuilder("react")
+        .with_memory("conversation", max_history=20)
+        .with_tool(CalculatorTool())
+        .with_config(max_steps=5)
+        .build()
+    )
+
+    return agent
+
+
+# ─── Step 4: Run the Full Pipeline ──────────────────────────────────────────
+
+def run_full_pipeline():
+    """Demonstrate the complete server → agent → tool flow."""
+
+    print("=" * 60)
+    print(" mcp_arena: Minimal End-to-End Example")
+    print("=" * 60)
+
+    # 1. Create the MCP server
+    print("\n--- Step 1: Create MCP Server ---")
+    server = MathServer()
+    print(f"Created server: {server.name}")
+    print(f"Registered tools: {server.get_registered_tools()}")
+
+    # 2. Wrap tools for agent use
+    print("\n--- Step 2: Wrap Tools ---")
+    wrapper = MCPAgentWrapper(server)
+    print(f"Wrapped {len(wrapper.tools)} tools for agent use")
+
+    # 3. Create an agent
+    print("\n--- Step 3: Create Agent ---")
+    agent = create_agent_with_builder()
+    print(f"Created agent: {type(agent).__name__}")
+
+    # 4. Process a query
+    print("\n--- Step 4: Process Query ---")
+    query = "What is 15 + 27?"
+    print(f"Query: {query}")
+
+    response = agent.process(query)
+    print(f"Response: {response}")
+
+    print("\n" + "=" * 60)
+    print(" Pipeline complete!")
+    print("=" * 60)
+
+
+# --- Entry Point ---
+if __name__ == "__main__":
+    run_full_pipeline()

--- a/examples/04_multi_tool_server.py
+++ b/examples/04_multi_tool_server.py
@@ -1,0 +1,154 @@
+"""
+04_multi_tool_server.py — MCP Server with Multiple Tools and Structured Data
+
+A slightly more advanced example showing how to build a server with
+multiple tools that return structured data. This pattern is common
+in real-world MCP servers (e.g., GitHub, Jira, Slack presets).
+
+Usage:
+    python 04_multi_tool_server.py
+
+What it demonstrates:
+    - Registering multiple tools in one server
+    - Returning structured (dict) responses from tools
+    - Using type hints for tool parameters
+    - Organizing tools with clear docstrings
+"""
+
+from typing import Optional
+from mcp_arena import BaseMCPServer
+
+
+# ─── In-Memory Data Store (simulates a database) ────────────────────────────
+
+CONTACTS = {
+    "alice": {"name": "Alice", "email": "alice@example.com", "role": "Engineer"},
+    "bob": {"name": "Bob", "email": "bob@example.com", "role": "Designer"},
+    "carol": {"name": "Carol", "email": "carol@example.com", "role": "Manager"},
+}
+
+
+# ─── Server Definition ──────────────────────────────────────────────────────
+
+class ContactServer(BaseMCPServer):
+    """MCP server for managing a simple contact list."""
+
+    def __init__(self):
+        super().__init__(
+            name="contact-server",
+            description="Manage a simple contact directory",
+            transport="stdio",
+        )
+
+    def _register_tools(self) -> None:
+        """Register contact management tools."""
+
+        @self.mcp_server.tool()
+        def list_contacts() -> dict:
+            """List all contacts in the directory.
+
+            Returns:
+                A dictionary with the total count and list of contacts.
+            """
+            return {
+                "total": len(CONTACTS),
+                "contacts": list(CONTACTS.values()),
+            }
+
+        @self.mcp_server.tool()
+        def get_contact(username: str) -> dict:
+            """Look up a contact by username.
+
+            Args:
+                username: The username to look up (e.g., 'alice').
+
+            Returns:
+                The contact details, or an error message if not found.
+            """
+            contact = CONTACTS.get(username.lower())
+            if contact:
+                return {"found": True, **contact}
+            return {"found": False, "error": f"No contact found for '{username}'"}
+
+        @self.mcp_server.tool()
+        def add_contact(
+            username: str,
+            name: str,
+            email: str,
+            role: Optional[str] = "Member",
+        ) -> dict:
+            """Add a new contact to the directory.
+
+            Args:
+                username: Unique username for the contact.
+                name: Full name of the contact.
+                email: Email address.
+                role: Role or title (defaults to 'Member').
+
+            Returns:
+                Confirmation with the created contact details.
+            """
+            if username.lower() in CONTACTS:
+                return {"success": False, "error": f"'{username}' already exists"}
+
+            CONTACTS[username.lower()] = {
+                "name": name,
+                "email": email,
+                "role": role,
+            }
+            return {
+                "success": True,
+                "message": f"Contact '{username}' added",
+                "contact": CONTACTS[username.lower()],
+            }
+
+        @self.mcp_server.tool()
+        def search_contacts(query: str) -> dict:
+            """Search contacts by name, email, or role.
+
+            Args:
+                query: Search term to match against contact fields.
+
+            Returns:
+                Matching contacts.
+            """
+            query_lower = query.lower()
+            matches = [
+                contact
+                for contact in CONTACTS.values()
+                if query_lower in contact["name"].lower()
+                or query_lower in contact["email"].lower()
+                or query_lower in contact["role"].lower()
+            ]
+            return {"query": query, "results": matches, "count": len(matches)}
+
+        self._registered_tools.extend([
+            "list_contacts",
+            "get_contact",
+            "add_contact",
+            "search_contacts",
+        ])
+
+        # --- Prompt: Contact lookup template ---
+        @self.mcp_server.prompt()
+        def lookup_prompt(username: str) -> str:
+            """Generate a prompt for looking up a contact.
+
+            Args:
+                username: The username to look up.
+
+            Returns:
+                A formatted prompt string.
+            """
+            return f"Look up the contact details for username '{username}' and summarize their information."
+
+
+# --- Entry Point ---
+if __name__ == "__main__":
+    server = ContactServer()
+
+    print(f"Server: {server.name}")
+    print(f"Tools:  {server.get_registered_tools()}")
+    print("Starting server on stdio transport...")
+
+    server.run()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,80 @@
+# Minimal End-to-End MCP Server Examples
+
+A collection of "hello-world" style examples demonstrating how to build and use MCP servers with `mcp_arena`. These examples are designed for **developer onboarding** — each one is self-contained, minimal, and well-commented.
+
+## Examples Overview
+
+| File | Description |
+|------|-------------|
+| `01_hello_server.py` | Minimal MCP server with a single tool |
+| `02_prompt_and_tool.py` | MCP server with a tool + a prompt template |
+| `03_agent_flow.py` | Full end-to-end: MCP server → Agent → Tool execution |
+| `04_multi_tool_server.py` | MCP server with multiple tools and structured responses |
+
+## Prerequisites
+
+```bash
+pip install mcp_arena
+```
+
+## Quick Start
+
+### 1. Run a Minimal Server
+
+```bash
+python 01_hello_server.py
+```
+
+This starts an MCP server with a single `greet` tool over stdio transport.
+
+### 2. Server with Prompt + Tool
+
+```bash
+python 02_prompt_and_tool.py
+```
+
+Demonstrates how to combine a tool with a reusable prompt template.
+
+### 3. Full Agent Flow
+
+```bash
+python 03_agent_flow.py
+```
+
+Shows the complete pipeline: create server → wrap tools → create agent → process query.
+
+### 4. Multi-Tool Server
+
+```bash
+python 04_multi_tool_server.py
+```
+
+A slightly more advanced example with multiple tools and structured data.
+
+## Architecture Overview
+
+```
+┌─────────────┐     ┌──────────────┐     ┌─────────────┐
+│  MCP Server  │────▶│  Agent       │────▶│  Tools      │
+│  (FastMCP)   │     │  (ReAct/     │     │  (greet,    │
+│              │     │   Reflect)   │     │   calc, ..) │
+└─────────────┘     └──────────────┘     └─────────────┘
+       │                    │
+       ▼                    ▼
+  Prompts/            Memory/State
+  Resources           Management
+```
+
+**Key Concepts:**
+- **BaseMCPServer**: Abstract base class — subclass it and implement `_register_tools()`
+- **Tools**: Functions decorated with `@self.mcp_server.tool()` inside your server
+- **Prompts**: Templates registered with `@self.mcp_server.prompt()`
+- **Agents**: Orchestrators (ReAct, Reflection, Planning) that use tools to answer queries
+- **MCPAgentWrapper**: Bridges MCP server tools into agent-compatible format
+
+## Next Steps
+
+- See [docs/QUICKSTART.md](../docs/QUICKSTART.md) for the full quickstart guide
+- See [docs/TOOLS_GUIDE.md](../docs/TOOLS_GUIDE.md) for all available built-in tools
+- See [docs/AGENT_GUIDE.md](../docs/AGENT_GUIDE.md) for agent configuration
+- See [docs/MCP_SERVERS_GUIDE.md](../docs/MCP_SERVERS_GUIDE.md) for preset servers


### PR DESCRIPTION
## Summary

Closes #33

Adds a set of minimal, self-contained examples in a new examples/ directory to help developers onboard quickly and understand the mcp_arena architecture.

## Examples Added

| File | Description |
|------|-------------|
| 