### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: "🐛 Bug Report"
+description: Report a bug or unexpected behavior in mcp_arena
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the sections below so we can reproduce and fix the issue quickly.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: Describe what went wrong...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: List the steps to reproduce the behavior.
+      placeholder: |
+        1. Import '...'
+        2. Create server with '...'
+        3. Call method '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include error messages or tracebacks if applicable.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: mcp_arena Version
+      description: "Run `pip show mcp_arena` to find out."
+      placeholder: "e.g., 0.2.3"
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python Version
+      description: "Run `python --version` to find out."
+      placeholder: "e.g., 3.12.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or logs that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "💬 Discussions"
+    url: https://github.com/SatyamSingh8306/mcp_arena/discussions
+    about: Ask questions or start a discussion (not a bug or feature request)

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,48 @@
+name: "📚 Documentation"
+description: Report missing, incorrect, or unclear documentation
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us improve the mcp_arena docs! Let us know what's missing, confusing, or incorrect.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Which part of the docs needs attention?
+      placeholder: "The section about X is missing information on..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type of Issue
+      options:
+        - Missing documentation
+        - Incorrect / outdated information
+        - Unclear or confusing explanation
+        - Typo or formatting issue
+        - New documentation needed
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: Link or path to the affected documentation page or file.
+      placeholder: "e.g., docs/QUICKSTART.md or README.md"
+    validations:
+      required: false
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Improvement
+      description: How would you improve the documentation?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: "✨ Feature Request"
+description: Suggest a new feature or enhancement for mcp_arena
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea to improve mcp_arena? We'd love to hear it! Please describe your feature request below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Is your feature request related to a problem? Describe it clearly.
+      placeholder: "I'm always frustrated when..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution or feature you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative approaches?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of mcp_arena does this relate to?
+      options:
+        - MCP Server (BaseMCPServer, presets)
+        - Agent (ReAct, Reflection, Planning)
+        - Tools (built-in tools)
+        - Wrapper (LangChain, agent wrapper)
+        - CLI
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, mockups, or examples that help explain the feature.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+## Description
+
+<!-- Provide a clear and concise description of your changes. -->
+
+
+
+## Related Issue
+
+<!-- Link the issue this PR addresses. Use "Closes #<number>" to auto-close it. -->
+
+Closes #
+
+## Type of Change
+
+<!-- Check the relevant option(s). -->
+
+- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds functionality)
+- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] 📚 Documentation (changes to docs only)
+- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
+- [ ] ✅ Tests (adding or updating tests)
+- [ ] 🔨 Chore (build process, CI, tooling changes)
+
+## Changes Made
+
+<!-- List the specific changes made in this PR. -->
+
+- 
+- 
+- 
+
+## How to Test
+
+<!-- Describe how reviewers can verify your changes. -->
+
+1. 
+2. 
+3. 
+
+## Checklist
+
+<!-- Ensure all items are checked before submitting. -->
+
+- [ ] My code follows the project's coding style
+- [ ] I have performed a self-review of my code
+- [ ] I have added/updated docstrings and comments where needed
+- [ ] I have added tests that prove my fix/feature works
+- [ ] New and existing tests pass locally (`pytest`)
+- [ ] I have updated the documentation if applicable
+
+## Screenshots / Logs
+
+<!-- If applicable, add screenshots or relevant log output. -->
+


### PR DESCRIPTION
## Summary

Closes #31

Adds structured GitHub issue templates and a pull request template to streamline contributions and reduce review overhead.

## Templates Added

### Issue Templates (.github/ISSUE_TEMPLATE/)

| Template | Description |
|----------|-------------|
| **Bug Report** (ug_report.yml) | Structured form: description, repro steps, expected/actual behavior, version, Python version, OS |
| **Feature Request** (eature_request.yml) | Problem/solution format with area dropdown (Server, Agent, Tools, Wrapper, CLI, Docs) |
| **Documentation** (documentation.yml) | For reporting missing, incorrect, or unclear docs |
| **Config** (config.yml) | Enables blank issues, links to GitHub Discussions |

### PR Template (.github/PULL_REQUEST_TEMPLATE.md)

Includes:
- Description and linked issue sections
- Type of change checkboxes (bug fix, feature, breaking change, docs, refactor, tests, chore)
- Changes made list
- How to test section
- Pre-submit checklist (style, self-review, docstrings, tests, docs)
- Screenshots/logs section

## Benefits

- Gives reviewers a quick overview of what each issue/PR is about
- Ensures contributors provide necessary context upfront
- Reduces back-and-forth during review
- Consistent structure across all issues and PRs