### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers of **mcp_arena** pledge to make participation in our project and community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+### Expected Behavior
+
+- **Be respectful** — Treat everyone with courtesy and consideration.
+- **Be constructive** — Offer helpful feedback and focus on improving the project.
+- **Be welcoming** — Help newcomers get started and feel included.
+- **Be collaborative** — Work together openly and share knowledge.
+- **Be accountable** — Own your mistakes, learn from them, and move forward.
+
+### Unacceptable Behavior
+
+- Harassment, intimidation, or discrimination in any form.
+- Trolling, insulting or derogatory comments, and personal attacks.
+- Publishing others' private information without explicit permission.
+- Sustained disruption of discussions, reviews, or project activities.
+- Any conduct that would be considered inappropriate in a professional setting.
+
+## Scope
+
+This Code of Conduct applies to all project spaces — including issues, pull requests, discussions, code reviews, and community channels — as well as public spaces where an individual is representing the project.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it by contacting the project maintainer:
+
+- **GitHub**: [@SatyamSingh8306](https://github.com/SatyamSingh8306)
+
+All reports will be reviewed and handled confidentially. The maintainer is committed to ensuring a safe environment for all contributors.
+
+## Enforcement
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and will take appropriate and fair action in response to any behavior that violates this Code of Conduct.
+
+Actions may include:
+
+1. **Warning** — A private notice explaining the violation.
+2. **Temporary restriction** — Temporary removal from project interactions.
+3. **Permanent ban** — Permanent removal from the project community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct/](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).


### PR DESCRIPTION
Closes #25

Adds a CODE_OF_CONDUCT.md based on the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) to help new contributors understand community standards.

**Sections:**
- Our Pledge
- Expected Behavior (respectful, constructive, welcoming, collaborative, accountable)
- Unacceptable Behavior
- Scope (issues, PRs, discussions, code reviews)
- Reporting (contact maintainer)
- Enforcement (warning, temporary restriction, permanent ban)

Kept concise and easy to read per the issue request.