### PR TITLE
Fix: Tool registration tracking, validation, and error handling

### DIFF
--- a/mcp_arena/mcp/__init__.py
+++ b/mcp_arena/mcp/__init__.py
@@ -1,3 +1,3 @@
-from .server import BaseMCPServer
+from .server import BaseMCPServer, ToolRegistrationError
 
-__all__ = ["BaseMCPServer"]
+__all__ = ["BaseMCPServer", "ToolRegistrationError"]

--- a/mcp_arena/mcp/server.py
+++ b/mcp_arena/mcp/server.py
@@ -1,6 +1,16 @@
 from abc import ABC, abstractmethod
-from typing import Literal, Annotated, Optional, Collection, List
+from typing import Literal, Annotated, Optional, Collection, List, Callable, Any, Dict
 from mcp.server.fastmcp import FastMCP
+import logging
+import inspect
+
+logger = logging.getLogger("mcp_arena.server")
+
+
+class ToolRegistrationError(Exception):
+    """Raised when a tool fails to register with the MCP server."""
+    pass
+
 
 class BaseMCPServer(ABC):
     def __init__(
@@ -66,16 +76,210 @@ class BaseMCPServer(ABC):
         
         # Store registered tools for reference
         self._registered_tools: List[str] = []
+        # Store tool metadata for introspection
+        self._tool_metadata: Dict[str, Dict[str, Any]] = {}
 
         if auto_register_tools:
             self._register_tools()
+            tool_count = len(self._registered_tools)
+            if tool_count > 0:
+                logger.info(
+                    "Server '%s' registered %d tool(s): %s",
+                    self.name,
+                    tool_count,
+                    ", ".join(self._registered_tools),
+                )
+            else:
+                logger.warning(
+                    "Server '%s' completed _register_tools() but no tools were registered. "
+                    "Ensure tools are registered using @self.mcp_server.tool() or self.register_tool().",
+                    self.name,
+                )
 
     @abstractmethod
     def _register_tools(self) -> None:
         """Register all tools with the MCP server."""
         pass
+
+    # ------------------------------------------------------------------
+    # Tool registration helpers
+    # ------------------------------------------------------------------
+
+    def tool(
+        self,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Callable:
+        """Decorator to register a tool with the MCP server.
+
+        This wraps FastMCP's ``tool()`` decorator while tracking tool names
+        in ``_registered_tools`` and providing clear error messages when
+        registration fails.
+
+        Args:
+            name: Optional name for the tool (defaults to function name).
+            description: Optional description of the tool.
+            **kwargs: Additional keyword arguments forwarded to FastMCP.tool().
+
+        Returns:
+            A decorator that registers the wrapped function as a tool.
+
+        Raises:
+            ToolRegistrationError: If the function is not callable or
+                registration with FastMCP fails.
+
+        Example::
+
+            server = MyMCPServer()
+
+            @server.tool()
+            def greet(name: str) -> str:
+                return f"Hello, {name}!"
+        """
+
+        def decorator(fn: Callable) -> Callable:
+            tool_name = name or getattr(fn, "__name__", str(fn))
+            self.register_tool(fn, name=name, description=description, **kwargs)
+            return fn
+
+        return decorator
+
+    def register_tool(
+        self,
+        fn: Callable,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Register a single tool function with the MCP server.
+
+        This is the imperative (non-decorator) counterpart of :meth:`tool`.
+        It validates the function, delegates to FastMCP, tracks the tool
+        in ``_registered_tools``, and logs the result.
+
+        Args:
+            fn: The callable to register as a tool.
+            name: Optional name (defaults to ``fn.__name__``).
+            description: Optional description.
+            **kwargs: Additional keyword arguments forwarded to ``FastMCP.add_tool``.
+
+        Returns:
+            The resolved tool name.
+
+        Raises:
+            ToolRegistrationError: If *fn* is not callable or FastMCP rejects
+                the tool.
+        """
+        tool_name = name or getattr(fn, "__name__", None)
+
+        # --- validation ---
+        if not callable(fn):
+            msg = f"Cannot register tool '{tool_name}': the object is not callable."
+            logger.error(msg)
+            raise ToolRegistrationError(msg)
+
+        if tool_name is None:
+            msg = (
+                "Cannot register tool: unable to determine a name. "
+                "Pass an explicit 'name' argument."
+            )
+            logger.error(msg)
+            raise ToolRegistrationError(msg)
+
+        if tool_name in self._registered_tools:
+            logger.warning(
+                "Tool '%s' is already registered on server '%s'. "
+                "Overwriting the previous registration.",
+                tool_name,
+                self.name,
+            )
+            # Remove the old entry so we can re-add cleanly
+            self._registered_tools.remove(tool_name)
+
+        # --- delegate to FastMCP ---
+        try:
+            self.mcp_server.add_tool(fn, name=name, description=description, **kwargs)
+        except Exception as exc:
+            msg = (
+                f"Failed to register tool '{tool_name}' on server '{self.name}': {exc}"
+            )
+            logger.error(msg)
+            raise ToolRegistrationError(msg) from exc
+
+        # --- bookkeeping ---
+        self._registered_tools.append(tool_name)
+        self._tool_metadata[tool_name] = {
+            "name": tool_name,
+            "description": description or (fn.__doc__ or "").strip().split("\n")[0],
+            "function": fn.__qualname__,
+            "module": getattr(fn, "__module__", None),
+        }
+        logger.debug("Registered tool '%s' on server '%s'.", tool_name, self.name)
+        return tool_name
+
+    def validate_tools(self) -> Dict[str, Any]:
+        """Validate that all tracked tools are present in the FastMCP registry.
+
+        Returns:
+            A dict with keys ``valid`` (bool), ``registered`` (list of tracked
+            tool names), ``missing`` (tools tracked but absent from FastMCP),
+            and ``untracked`` (tools in FastMCP but not tracked here).
+        """
+        tracked = set(self._registered_tools)
+
+        # FastMCP stores tools in _tool_manager._tools
+        try:
+            fastmcp_tools = set(self.mcp_server._tool_manager._tools.keys())
+        except AttributeError:
+            # Fallback: if internal API changes, report what we can
+            logger.warning(
+                "Could not introspect FastMCP tool registry for server '%s'.",
+                self.name,
+            )
+            return {
+                "valid": None,
+                "registered": sorted(tracked),
+                "missing": [],
+                "untracked": [],
+            }
+
+        missing = sorted(tracked - fastmcp_tools)
+        untracked = sorted(fastmcp_tools - tracked)
+
+        if missing:
+            logger.error(
+                "Server '%s': tools tracked but missing from FastMCP registry: %s",
+                self.name,
+                ", ".join(missing),
+            )
+        if untracked:
+            logger.warning(
+                "Server '%s': tools in FastMCP registry but not tracked: %s. "
+                "Use server.tool() or server.register_tool() to register tools "
+                "so they are properly tracked.",
+                self.name,
+                ", ".join(untracked),
+            )
+
+        return {
+            "valid": len(missing) == 0,
+            "registered": sorted(tracked),
+            "missing": missing,
+            "untracked": untracked,
+        }
     
     def __getattr__(self, name):
+        # Prevent __getattr__ from silently forwarding tool() to FastMCP
+        # which would bypass our tracking. All other attributes still
+        # delegate to the underlying FastMCP server.
+        if name == "tool":
+            raise AttributeError(
+                f"Use '{type(self).__name__}.tool()' decorator or "
+                f"'{type(self).__name__}.register_tool()' to register tools. "
+                f"Direct access to the underlying FastMCP tool() decorator "
+                f"bypasses tool tracking and validation."
+            )
         return getattr(self.mcp_server, name)
 
     def get_registered_tools(self) -> List[str]:
@@ -85,6 +289,15 @@ class BaseMCPServer(ABC):
             List of registered tool names
         """
         return self._registered_tools.copy()
+
+    def get_tool_metadata(self) -> Dict[str, Dict[str, Any]]:
+        """Get metadata for all registered tools.
+
+        Returns:
+            A dict mapping tool names to their metadata (name, description,
+            function, module).
+        """
+        return {k: dict(v) for k, v in self._tool_metadata.items()}
 
     def run(self, transport: Optional[Literal['stdio', 'sse', 'streamable-http']] = None) -> None:
         """Run the MCP server.

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -1,0 +1,418 @@
+"""Tests for tool registration, validation, and error handling.
+
+Covers the fixes for issue #43: Incorrect Tool Registration Leads to Silent
+Failures in Custom Tools.
+"""
+
+import logging
+import pytest
+from typing import Annotated, Dict, Any, Literal, Optional
+
+from mcp_arena.mcp.server import BaseMCPServer, ToolRegistrationError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class MinimalServer(BaseMCPServer):
+    """Minimal concrete server that registers no tools (for testing)."""
+
+    def __init__(self, auto_register_tools: bool = False, **kwargs):
+        super().__init__(
+            name="TestServer",
+            description="A server for unit tests",
+            auto_register_tools=auto_register_tools,
+            **kwargs,
+        )
+
+    def _register_tools(self) -> None:
+        """No tools registered by default."""
+        pass
+
+
+class ServerWithTools(BaseMCPServer):
+    """Server that registers tools through the mcp_server.tool() decorator."""
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            name="ToolServer",
+            description="Server that registers tools",
+            auto_register_tools=True,
+            **kwargs,
+        )
+
+    def _register_tools(self) -> None:
+        @self.mcp_server.tool()
+        def greet(name: str) -> str:
+            """Say hello."""
+            return f"Hello, {name}!"
+
+        # Track via _registered_tools manually (old-style, still used by presets)
+        self._registered_tools.append("greet")
+
+
+class ServerUsingRegisterTool(BaseMCPServer):
+    """Server that registers tools via the new register_tool() API."""
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            name="RegisterToolServer",
+            description="Server using register_tool",
+            auto_register_tools=True,
+            **kwargs,
+        )
+
+    def _register_tools(self) -> None:
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        def multiply(a: int, b: int) -> int:
+            """Multiply two numbers."""
+            return a * b
+
+        self.register_tool(add)
+        self.register_tool(multiply, name="mul", description="Multiply two integers")
+
+
+# ---------------------------------------------------------------------------
+# Tests – basic registration tracking
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistrationTracking:
+    """Verify that _registered_tools is properly populated."""
+
+    def test_no_tools_registered_returns_empty(self):
+        server = MinimalServer(auto_register_tools=False)
+        assert server.get_registered_tools() == []
+
+    def test_server_with_manual_tracking(self):
+        server = ServerWithTools()
+        tools = server.get_registered_tools()
+        assert "greet" in tools
+
+    def test_register_tool_tracks_name(self):
+        server = MinimalServer()
+
+        def echo(msg: str) -> str:
+            return msg
+
+        server.register_tool(echo)
+        assert "echo" in server.get_registered_tools()
+
+    def test_register_tool_with_custom_name(self):
+        server = MinimalServer()
+
+        def echo(msg: str) -> str:
+            return msg
+
+        returned_name = server.register_tool(echo, name="my_echo")
+        assert returned_name == "my_echo"
+        assert "my_echo" in server.get_registered_tools()
+        assert "echo" not in server.get_registered_tools()
+
+    def test_decorator_tracks_tool(self):
+        server = MinimalServer()
+
+        @server.tool()
+        def ping() -> str:
+            """Ping."""
+            return "pong"
+
+        assert "ping" in server.get_registered_tools()
+
+    def test_decorator_with_custom_name(self):
+        server = MinimalServer()
+
+        @server.tool(name="health_check")
+        def ping() -> str:
+            return "pong"
+
+        assert "health_check" in server.get_registered_tools()
+        assert "ping" not in server.get_registered_tools()
+
+    def test_multiple_tools_tracked(self):
+        server = ServerUsingRegisterTool()
+        tools = server.get_registered_tools()
+        assert "add" in tools
+        assert "mul" in tools
+        assert len(tools) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests – tool metadata
+# ---------------------------------------------------------------------------
+
+
+class TestToolMetadata:
+    """Verify tool metadata is correctly populated."""
+
+    def test_metadata_populated(self):
+        server = MinimalServer()
+
+        def greet(name: str) -> str:
+            """Say hello to someone."""
+            return f"Hi {name}"
+
+        server.register_tool(greet)
+        meta = server.get_tool_metadata()
+        assert "greet" in meta
+        assert meta["greet"]["name"] == "greet"
+        assert "Say hello" in meta["greet"]["description"]
+
+    def test_metadata_custom_description(self):
+        server = MinimalServer()
+
+        def noop() -> None:
+            pass
+
+        server.register_tool(noop, description="Does nothing at all")
+        meta = server.get_tool_metadata()
+        assert meta["noop"]["description"] == "Does nothing at all"
+
+    def test_metadata_returns_copies(self):
+        server = MinimalServer()
+
+        def noop() -> None:
+            pass
+
+        server.register_tool(noop)
+        meta1 = server.get_tool_metadata()
+        meta2 = server.get_tool_metadata()
+        assert meta1 is not meta2
+        assert meta1["noop"] is not meta2["noop"]
+
+
+# ---------------------------------------------------------------------------
+# Tests – validation
+# ---------------------------------------------------------------------------
+
+
+class TestToolValidation:
+    """Verify validate_tools() works."""
+
+    def test_validate_no_tools(self):
+        server = MinimalServer()
+        result = server.validate_tools()
+        assert result["valid"] is True
+        assert result["registered"] == []
+        assert result["missing"] == []
+
+    def test_validate_registered_tools(self):
+        server = MinimalServer()
+
+        @server.tool()
+        def hello() -> str:
+            return "hi"
+
+        result = server.validate_tools()
+        assert result["valid"] is True
+        assert "hello" in result["registered"]
+
+    def test_validate_detects_untracked(self):
+        """Tools registered directly on FastMCP should appear as untracked."""
+        server = MinimalServer()
+
+        # Register directly on FastMCP bypassing our tracking
+        @server.mcp_server.tool()
+        def secret_tool() -> str:
+            return "secret"
+
+        result = server.validate_tools()
+        assert "secret_tool" in result["untracked"]
+
+
+# ---------------------------------------------------------------------------
+# Tests – error handling
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistrationErrors:
+    """Verify that errors are raised (not silently swallowed)."""
+
+    def test_register_non_callable_raises(self):
+        server = MinimalServer()
+        with pytest.raises(ToolRegistrationError, match="not callable"):
+            server.register_tool("not_a_function", name="bad_tool")
+
+    def test_register_none_raises(self):
+        server = MinimalServer()
+        with pytest.raises(ToolRegistrationError, match="not callable"):
+            server.register_tool(None, name="none_tool")
+
+    def test_register_without_name_raises(self):
+        """Lambdas have __name__ == '<lambda>', which is valid, but an
+        object with no __name__ and no explicit name should fail."""
+        server = MinimalServer()
+
+        class NoName:
+            def __call__(self):
+                pass
+
+        obj = NoName()
+        # Remove __name__ if it exists
+        if hasattr(obj, "__name__"):
+            delattr(obj, "__name__")
+        # The callable check should pass but name resolution may vary,
+        # this just verifies no silent failure.
+        # NoName instances are callable, so register_tool should work
+        # (it will use the class's __qualname__ or similar).
+        # The key point is: it doesn't silently fail.
+        try:
+            server.register_tool(obj)
+        except ToolRegistrationError:
+            pass  # Expected if name can't be resolved
+        # Either way, no silent failure occurred
+
+    def test_duplicate_tool_warns(self, caplog):
+        server = MinimalServer()
+
+        def my_tool() -> str:
+            return "v1"
+
+        def my_tool_v2() -> str:
+            return "v2"
+
+        server.register_tool(my_tool, name="dup")
+
+        with caplog.at_level(logging.WARNING, logger="mcp_arena.server"):
+            server.register_tool(my_tool_v2, name="dup")
+
+        assert "already registered" in caplog.text
+        # Should still have exactly one entry
+        assert server.get_registered_tools().count("dup") == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests – logging
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistrationLogging:
+    """Verify proper log output during tool registration."""
+
+    def test_debug_log_on_register(self, caplog):
+        server = MinimalServer()
+
+        def my_tool() -> str:
+            return "ok"
+
+        with caplog.at_level(logging.DEBUG, logger="mcp_arena.server"):
+            server.register_tool(my_tool)
+
+        assert "Registered tool 'my_tool'" in caplog.text
+
+    def test_warning_when_no_tools_registered(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="mcp_arena.server"):
+            server = MinimalServer(auto_register_tools=True)
+
+        assert "no tools were registered" in caplog.text
+
+    def test_info_log_when_tools_registered(self, caplog):
+        with caplog.at_level(logging.INFO, logger="mcp_arena.server"):
+            server = ServerUsingRegisterTool()
+
+        assert "registered 2 tool(s)" in caplog.text
+
+    def test_error_log_on_non_callable(self, caplog):
+        server = MinimalServer()
+        with caplog.at_level(logging.ERROR, logger="mcp_arena.server"):
+            with pytest.raises(ToolRegistrationError):
+                server.register_tool(42, name="bad")
+
+        assert "not callable" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Tests – __getattr__ guard
+# ---------------------------------------------------------------------------
+
+
+class TestGetAttrGuard:
+    """Verify that __getattr__ blocks direct access to .tool()."""
+
+    def test_direct_tool_access_raises(self):
+        server = MinimalServer()
+        # Accessing server.tool should work (it's a real method now)
+        assert callable(server.tool)
+
+    def test_other_attrs_delegate(self):
+        """Non-tool attributes should still delegate to FastMCP."""
+        server = MinimalServer()
+        # FastMCP has an .name attribute
+        assert server.mcp_server.name == "TestServer"
+
+    def test_getattr_still_works_for_fastmcp(self):
+        """Attributes that exist on FastMCP but not BaseMCPServer should
+        still be accessible via __getattr__."""
+        server = MinimalServer()
+        # FastMCP instances have add_tool
+        assert callable(server.add_tool)
+
+
+# ---------------------------------------------------------------------------
+# Tests – decorator returns original function
+# ---------------------------------------------------------------------------
+
+
+class TestDecoratorBehavior:
+    """Verify the tool() decorator returns the original function."""
+
+    def test_decorator_returns_function(self):
+        server = MinimalServer()
+
+        @server.tool()
+        def my_func(x: int) -> int:
+            return x * 2
+
+        assert callable(my_func)
+        assert my_func(5) == 10
+
+    def test_decorator_preserves_docstring(self):
+        server = MinimalServer()
+
+        @server.tool()
+        def documented() -> str:
+            """This is documented."""
+            return "ok"
+
+        assert documented.__doc__ == "This is documented."
+
+
+# ---------------------------------------------------------------------------
+# Tests – get_registered_tools returns copy
+# ---------------------------------------------------------------------------
+
+
+class TestGetRegisteredToolsIsolation:
+    """Verify get_registered_tools returns a copy."""
+
+    def test_returns_copy(self):
+        server = MinimalServer()
+
+        @server.tool()
+        def t1() -> str:
+            return "ok"
+
+        tools = server.get_registered_tools()
+        tools.append("fake_tool")
+        assert "fake_tool" not in server.get_registered_tools()
+
+
+# ---------------------------------------------------------------------------
+# Tests – ToolRegistrationError is importable
+# ---------------------------------------------------------------------------
+
+
+class TestImports:
+    """Verify public API imports work."""
+
+    def test_import_from_mcp_module(self):
+        from mcp_arena.mcp import ToolRegistrationError as TRE
+        assert TRE is ToolRegistrationError
+
+    def test_import_from_server_module(self):
+        from mcp_arena.mcp.server import ToolRegistrationError as TRE
+        assert TRE is ToolRegistrationError


### PR DESCRIPTION
Closes #43

## Problem

Custom tools registered via `@mcp_server.tool()` silently fail to appear in `get_registered_tools()` because `_registered_tools` is never populated. No errors or logs are emitted when registration fails, making debugging impossible.

## Root Causes

1. **`_registered_tools` never updated** — Subclasses register tools via `@self.mcp_server.tool()` but the list is never populated, so `get_registered_tools()` always returns `[]`.
2. **No `tool()` method on `BaseMCPServer`** — `@server.tool()` falls through `__getattr__` to FastMCP with zero tracking/validation.
3. **No error handling or logging** — Failed registrations are completely silent.

## Fix

### `mcp_arena/mcp/server.py`
- **`tool()` decorator** on `BaseMCPServer` — wraps FastMCP's decorator with tracking, validation, and logging.
- **`register_tool()` method** — imperative API that validates the callable, delegates to `FastMCP.add_tool()`, tracks the tool name, stores metadata, and logs the result.
- **`validate_tools()`** — introspects FastMCP's internal `_tool_manager._tools` to detect missing or untracked tools.
- **`get_tool_metadata()`** — returns name, description, function, and module for each tool.
- **`ToolRegistrationError`** — raised with clear messages on non-callable input, missing name, or FastMCP rejection.
- **`__getattr__` guard** — blocks `server.tool` from silently delegating to FastMCP (use `server.tool()` or `server.register_tool()` instead).
- **Logging** — INFO when tools are registered, WARNING when none are found after `_register_tools()`, ERROR on failures, DEBUG per-tool.

### `tests/test_tool_registration.py` — 29 tests
- Registration tracking (7 tests)
- Tool metadata (3 tests)
- Validation (3 tests)
- Error handling (4 tests)
- Logging output (4 tests)
- `__getattr__` guard (3 tests)
- Decorator behavior (2 tests)
- Isolation / imports (3 tests)
